### PR TITLE
feat: Add agentic tools and MCP server

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -85,36 +85,65 @@ Refer to `README.md` for full usage. Key commands include:
 
 ## Interacting via MCP
 
-AIPSEO includes an MCP server that exposes tools for AI agents. You can interact with these tools by connecting to the server using an MCP client.
+AIPSEO includes an MCP server that exposes tools for AI agents, primarily sourced from `aipseo/agent_tools.py`. You can interact with these tools by connecting to the server using an MCP client.
 
 The server is defined in `aipseo/mcp_server.py` and can be run (for development/testing) using an ASGI server like Uvicorn:
 ```bash
-uvicorn aipseo.mcp_server:mcp_server --host 0.0.0.0 --port 8000
+uvicorn aipseo.mcp_server:mcp_server --host 0.0.0.0 --port 8000 --reload
 ```
+(Note: The `--reload` flag is useful for development to automatically pick up code changes.)
 
 ### Available MCP Tools
 
-#### `analyze_seo_content`
+The following tools are registered with the MCP server and available for use:
 
-*   **Description**: Analyzes a given piece of text content for SEO best practices against a target keyword.
+#### `get_url_lookup`
+
+*   **Signature**: `get_url_lookup(url: str) -> dict`
+*   **Description**: Retrieves lookup information (metadata, metrics) for a given URL.
 *   **Parameters**:
-    *   `content` (string): The text content to analyze.
-    *   `keyword` (string): The target keyword for the analysis.
-*   **Returns**: (string) A summary of the SEO analysis and actionable recommendations.
-*   **Example (conceptual)**:
-    ```python
-    # Assuming you have an MCP client instance `mcp_client`
-    # connected to the AIPSEO MCP server.
+    *   `url` (str): The URL to look up.
+*   **Returns**: (dict) A dictionary containing the lookup data for the URL.
 
-    article_text = "This is my new blog post about amazing widgets."
-    focus_keyword = "amazing widgets"
+#### `get_spam_score`
 
-    try:
-        seo_feedback = mcp_client.tools.analyze_seo_content(content=article_text, keyword=focus_keyword)
-        print("SEO Feedback:", seo_feedback)
-    except Exception as e:
-        print(f"Error calling analyze_seo_content: {e}")
-    ```
+*   **Signature**: `get_spam_score(url: str) -> dict`
+*   **Description**: Fetches the spam score for a specified URL.
+*   **Parameters**:
+    *   `url` (str): The URL to get the spam score for.
+*   **Returns**: (dict) A dictionary containing the spam score result.
+
+#### `list_market_opportunities`
+
+*   **Signature**: `list_market_opportunities(dr_min: Optional[int] = None, price_max: Optional[float] = None, topic: Optional[str] = None) -> list`
+*   **Description**: Lists available backlink opportunities from the marketplace, with optional filters for Domain Rating (DR), maximum price, and topic.
+*   **Parameters**:
+    *   `dr_min` (Optional[int]): Minimum Domain Rating.
+    *   `price_max` (Optional[float]): Maximum price.
+    *   `topic` (Optional[str]): Desired topic for backlinks.
+*   **Returns**: (list) A list of market opportunities matching the criteria.
+
+#### `get_wallet_balance`
+
+*   **Signature**: `get_wallet_balance(wallet_id: str) -> dict`
+*   **Description**: Gets the current balance for a specified wallet ID.
+*   **Parameters**:
+    *   `wallet_id` (str): The ID of the wallet to get the balance for.
+*   **Returns**: (dict) A dictionary containing the wallet balance result.
+
+---
+(Note: The `analyze_seo_content` tool, previously mentioned in this guide, is described for context but is not currently enabled in the default `aipseo/mcp_server.py`.)
+---
+
+### Obtaining Tool Schemas
+
+AI agents can obtain machine-readable schemas for these tools, which is useful for function calling and ensuring correct parameter usage. The `aipseo toolspec` command now includes schemas for both the standard CLI commands and the agent tools exposed via MCP.
+
+To get the OpenAI-compatible schemas:
+```bash
+aipseo toolspec --format openai
+```
+This output will contain a JSON array of tool specifications, including `get_url_lookup`, `get_spam_score`, `list_market_opportunities`, and `get_wallet_balance`.
 
 ## AI Assistant Guidelines
 

--- a/aipseo/agent_tools.py
+++ b/aipseo/agent_tools.py
@@ -1,0 +1,70 @@
+# spdx-license-identifier: apache-2.0
+# copyright 2024 mark counterman
+
+from typing import Optional
+
+from aipseo.api import APIClient
+
+
+def get_url_lookup(url: str) -> dict:
+    """
+    Performs a URL lookup using the APIClient.
+
+    Args:
+        url: The URL to lookup.
+
+    Returns:
+        A dictionary containing the lookup result.
+    """
+    client = APIClient()
+    return client.lookup(url)
+
+
+def get_spam_score(url: str) -> dict:
+    """
+    Retrieves the spam score for a given URL using the APIClient.
+
+    Args:
+        url: The URL to get the spam score for.
+
+    Returns:
+        A dictionary containing the spam score result.
+    """
+    client = APIClient()
+    return client.spam_score(url)
+
+
+def list_market_opportunities(
+    dr_min: Optional[int] = None,
+    price_max: Optional[float] = None,
+    topic: Optional[str] = None,
+) -> list:
+    """
+    Lists market opportunities based on the provided filters using the APIClient.
+
+    Args:
+        dr_min: Optional minimum domain rating.
+        price_max: Optional maximum price.
+        topic: Optional topic to filter by.
+
+    Returns:
+        A list of market opportunities.
+    """
+    client = APIClient()
+    return client.search_marketplace(
+        dr_min=dr_min, price_max=price_max, topic=topic
+    )
+
+
+def get_wallet_balance(wallet_id: str) -> dict:
+    """
+    Retrieves the balance for a given wallet ID using the APIClient.
+
+    Args:
+        wallet_id: The ID of the wallet to get the balance for.
+
+    Returns:
+        A dictionary containing the wallet balance result.
+    """
+    client = APIClient()
+    return client.get_balance(wallet_id)

--- a/aipseo/mcp_server.py
+++ b/aipseo/mcp_server.py
@@ -1,0 +1,28 @@
+# spdx-license-identifier: apache-2.0
+# copyright 2024 mark counterman
+
+import uvicorn
+from mcp.server import Server, ToolRegistry
+
+from aipseo.agent_tools import (
+    get_url_lookup,
+    get_spam_score,
+    list_market_opportunities,
+    get_wallet_balance,
+)
+
+# Create a ToolRegistry instance
+registry = ToolRegistry()
+
+# Register the functions from agent_tools
+registry.register(get_url_lookup)
+registry.register(get_spam_score)
+registry.register(list_market_opportunities)
+registry.register(get_wallet_balance)
+
+# Create a Server instance
+mcp_server = Server(registry=registry)
+
+# Main execution block to run the server
+if __name__ == "__main__":
+    uvicorn.run("aipseo.mcp_server:mcp_server", host="0.0.0.0", port=8000, reload=True)

--- a/aipseo/toolspec.py
+++ b/aipseo/toolspec.py
@@ -6,8 +6,8 @@
 
 import inspect
 import json
-from typing import Any, Dict, List, Optional, Union
-from typing import get_args, get_origin
+import sys # Added for printing notices to stderr
+from typing import Any, Dict, List, Optional, Union, get_args, get_origin
 
 import typer
 
@@ -25,6 +25,63 @@ def _map_type(annotation: Any) -> str:
     if annotation is float:
         return "number"
     return "string"
+
+
+def _generate_schema_for_callable(func: Any, name_override: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Generates an OpenAI-compatible schema for a given Python callable.
+    """
+    func_name = name_override or func.__name__
+    description = inspect.getdoc(func) or ""
+    sig = inspect.signature(func)
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+
+    for param in sig.parameters.values():
+        param_name = param.name
+        annotation = param.annotation
+
+        is_optional = False
+        actual_annotation = annotation
+        origin = get_origin(annotation)
+        if origin is Union: # Handles Optional[X] which is Union[X, NoneType]
+            union_args = get_args(annotation)
+            if type(None) in union_args:
+                is_optional = True
+                non_none_args = [arg for arg in union_args if arg is not type(None)]
+                if non_none_args:
+                    actual_annotation = non_none_args[0]
+                # If non_none_args is empty, it means annotation was Union[NoneType]
+                # In such a case, actual_annotation remains NoneType, and _map_type will handle it.
+
+        json_type = _map_type(actual_annotation)
+        prop: Dict[str, Any] = {"type": json_type}
+        
+        # Parameter description (omitted for simplicity as per instructions)
+        # prop["description"] = "Parsed description for " + param_name
+
+        properties[param_name] = prop
+
+        if param.default is inspect.Parameter.empty and not is_optional:
+            required.append(param_name)
+        elif param.default is not inspect.Parameter.empty:
+            try:
+                # Ensure default value is suitable for JSON
+                json.dumps(param.default)
+                prop["default"] = param.default
+            except TypeError:
+                # Default value is not JSON serializable, skip adding it.
+                # Or represent it as a string, e.g., prop["x-python-default"] = str(param.default)
+                pass # As per instructions
+
+    schema: Dict[str, Any] = {
+        "name": func_name,
+        "description": description,
+        "parameters": {"type": "object", "properties": properties},
+    }
+    if required:
+        schema["parameters"]["required"] = required
+    return schema
 
 
 def generate_openai_spec() -> List[Dict[str, Any]]:
@@ -88,6 +145,31 @@ def generate_openai_spec() -> List[Dict[str, Any]]:
         for cmd_info in group_info.typer_instance.registered_commands:
             override = f"{group_name}_{cmd_info.callback.__name__}"
             process_command(cmd_info.callback, name_override=override)
+
+    # Add specs for agent_tools
+    try:
+        from aipseo import agent_tools # Import the module
+
+        # List of functions from agent_tools to expose
+        agent_tool_functions = [
+            agent_tools.get_url_lookup,
+            agent_tools.get_spam_score,
+            agent_tools.list_market_opportunities,
+            agent_tools.get_wallet_balance,
+        ]
+
+        for func_to_spec in agent_tool_functions:
+            # Ensure the function is callable before trying to generate a spec
+            if callable(func_to_spec):
+                tool_schema = _generate_schema_for_callable(func_to_spec) # Call the new helper
+                specs.append(tool_schema)
+    except ImportError:
+        # agent_tools.py might not be present, or specific tools are not yet defined.
+        # This allows toolspec to run without erroring if they are missing.
+        print("Notice: aipseo.agent_tools not found or functions missing, skipping their spec generation.", file=sys.stderr)
+    except AttributeError as e:
+        # Handle cases where agent_tools exists but a specific function is missing
+        print(f"Notice: Attribute error while processing agent_tools: {e}", file=sys.stderr)
 
     return specs
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,118 @@
+# spdx-license-identifier: apache-2.0
+# copyright 2024 mark counterman
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Functions to test
+from aipseo.agent_tools import (
+    get_url_lookup,
+    get_spam_score,
+    list_market_opportunities,
+    get_wallet_balance,
+)
+# To help with type hinting the mock APIClient instance
+from aipseo.api import APIClient
+
+
+class TestAgentTools(unittest.TestCase):
+
+    @patch('aipseo.agent_tools.APIClient')
+    def test_get_url_lookup(self, MockAPIClient: MagicMock) -> None:
+        # Setup mock instance and its method's return value
+        mock_api_instance = MockAPIClient.return_value
+        expected_data = {"url": "example.com", "data": "some_lookup_data"}
+        mock_api_instance.lookup.return_value = expected_data
+
+        # Call the function
+        result = get_url_lookup(url="example.com")
+
+        # Assertions
+        MockAPIClient.assert_called_once_with()  # Ensure APIClient was instantiated
+        mock_api_instance.lookup.assert_called_once_with(url="example.com")
+        self.assertEqual(result, expected_data)
+
+    @patch('aipseo.agent_tools.APIClient')
+    def test_get_spam_score(self, MockAPIClient: MagicMock) -> None:
+        # Setup mock instance
+        mock_api_instance = MockAPIClient.return_value
+        expected_data = {"url": "example.com", "score": 10}
+        mock_api_instance.spam_score.return_value = expected_data
+
+        # Call the function
+        result = get_spam_score(url="example.com")
+
+        # Assertions
+        MockAPIClient.assert_called_once_with()
+        mock_api_instance.spam_score.assert_called_once_with(url="example.com")
+        self.assertEqual(result, expected_data)
+
+    @patch('aipseo.agent_tools.APIClient')
+    def test_list_market_opportunities(self, MockAPIClient: MagicMock) -> None:
+        # Setup mock instance
+        mock_api_instance = MockAPIClient.return_value
+        expected_data = [{"id": "1", "dr": 70, "price": 90, "topic": "tech"}]
+        mock_api_instance.search_marketplace.return_value = expected_data
+
+        # Call the function
+        result = list_market_opportunities(dr_min=70, price_max=100.0, topic="tech")
+
+        # Assertions
+        MockAPIClient.assert_called_once_with()
+        mock_api_instance.search_marketplace.assert_called_once_with(
+            dr_min=70, price_max=100.0, topic="tech"
+        )
+        self.assertEqual(result, expected_data)
+
+    @patch('aipseo.agent_tools.APIClient')
+    def test_list_market_opportunities_no_args(self, MockAPIClient: MagicMock) -> None:
+        # Setup mock instance
+        mock_api_instance = MockAPIClient.return_value
+        expected_data = [{"id": "2", "dr": 50}]
+        mock_api_instance.search_marketplace.return_value = expected_data
+
+        # Call the function
+        result = list_market_opportunities()
+
+        # Assertions
+        MockAPIClient.assert_called_once_with()
+        mock_api_instance.search_marketplace.assert_called_once_with(
+            dr_min=None, price_max=None, topic=None
+        )
+        self.assertEqual(result, expected_data)
+        
+    @patch('aipseo.agent_tools.APIClient')
+    def test_list_market_opportunities_some_args(self, MockAPIClient: MagicMock) -> None:
+        # Setup mock instance
+        mock_api_instance = MockAPIClient.return_value
+        expected_data = [{"id": "3", "dr": 60, "topic": "finance"}]
+        mock_api_instance.search_marketplace.return_value = expected_data
+
+        # Call the function
+        result = list_market_opportunities(dr_min=60, topic="finance")
+
+        # Assertions
+        MockAPIClient.assert_called_once_with()
+        mock_api_instance.search_marketplace.assert_called_once_with(
+            dr_min=60, price_max=None, topic="finance"
+        )
+        self.assertEqual(result, expected_data)
+
+    @patch('aipseo.agent_tools.APIClient')
+    def test_get_wallet_balance(self, MockAPIClient: MagicMock) -> None:
+        # Setup mock instance
+        mock_api_instance = MockAPIClient.return_value
+        expected_data = {"wallet_id": "wallet123", "balance": 500}
+        mock_api_instance.get_balance.return_value = expected_data
+
+        # Call the function
+        result = get_wallet_balance(wallet_id="wallet123")
+
+        # Assertions
+        MockAPIClient.assert_called_once_with()
+        mock_api_instance.get_balance.assert_called_once_with(wallet_id="wallet123")
+        self.assertEqual(result, expected_data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,61 @@
+# spdx-license-identifier: apache-2.0
+# copyright 2024 mark counterman
+
+import unittest
+from mcp.server import ToolRegistry
+
+# Expected tools that should be registered (imported for clarity/reference)
+from aipseo.agent_tools import (
+    get_url_lookup,
+    get_spam_score,
+    list_market_opportunities,
+    get_wallet_balance
+)
+
+# The registry instance from mcp_server.py
+# This relies on aipseo.mcp_server.py defining 'registry' at the module level
+try:
+    from aipseo.mcp_server import registry as mcp_server_registry
+except ImportError as e:
+    # This allows tests to be discovered and run, even if mcp_server itself has issues.
+    # The test method will then fail gracefully.
+    mcp_server_registry = None 
+    print(f"Could not import mcp_server_registry: {e}")
+
+
+class TestMCPServer(unittest.TestCase):
+
+    def test_tools_are_registered(self):
+        self.assertIsNotNone(mcp_server_registry, 
+                             "MCP server registry (from aipseo.mcp_server) could not be imported. "
+                             "This may indicate an issue with aipseo/mcp_server.py or its dependencies.")
+        
+        self.assertIsInstance(mcp_server_registry, ToolRegistry, 
+                              "The imported 'registry' from aipseo.mcp_server is not a ToolRegistry instance.")
+
+        expected_tool_names = sorted([ # Use sorted list for consistent comparison
+            "get_url_lookup",
+            "get_spam_score",
+            "list_market_opportunities",
+            "get_wallet_balance",
+        ])
+        
+        # mcp_server_registry.get_tools() yields (name, callable) tuples
+        # We only need the names for this test.
+        registered_tool_names = sorted([tool_name for tool_name, _ in mcp_server_registry.get_tools()])
+
+        # Check if all expected tools are registered
+        for tool_name in expected_tool_names:
+            self.assertIn(tool_name, registered_tool_names, 
+                          f"Expected tool '{tool_name}' not found in MCP server registry.")
+        
+        # Check if the number of registered tools matches the number of expected tools
+        # This ensures no unexpected tools are registered.
+        self.assertEqual(len(registered_tool_names), len(expected_tool_names),
+                         f"Mismatch in the number of registered tools. "
+                         f"Expected: {len(expected_tool_names)}, Found: {len(registered_tool_names)}. "
+                         f"Registered tools: {registered_tool_names}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_toolspec.py
+++ b/tests/test_toolspec.py
@@ -1,0 +1,108 @@
+# spdx-license-identifier: apache-2.0
+# copyright 2024 mark counterman
+
+import unittest
+import inspect # For getting docstrings consistently
+from aipseo.toolspec import generate_openai_spec
+
+# Import agent tools to compare docstrings and parameter details
+from aipseo.agent_tools import (
+    get_url_lookup,
+    get_spam_score,
+    list_market_opportunities,
+    get_wallet_balance,
+)
+
+class TestToolSpecGeneration(unittest.TestCase):
+
+    def setUp(self):
+        # Generate the specs once for all tests in this class
+        self.all_specs = generate_openai_spec()
+        self.generated_tool_names = [spec["name"] for spec in self.all_specs]
+
+    def find_schema_by_name(self, name: str):
+        for spec in self.all_specs:
+            if spec["name"] == name:
+                return spec
+        return None
+
+    def test_generate_openai_spec_includes_agent_tools(self):
+        expected_agent_tool_names = [
+            "get_url_lookup",
+            "get_spam_score",
+            "list_market_opportunities",
+            "get_wallet_balance",
+        ]
+        for name in expected_agent_tool_names:
+            self.assertIn(name, self.generated_tool_names,
+                          f"Agent tool '{name}' not found in toolspec output.")
+
+    def test_toolspec_includes_cli_commands(self):
+        # Check for a few representative CLI commands
+        # These names are based on the Typer command structure and toolspec.py naming logic
+        expected_cli_tool_names = ["lookup", "spam-score", "wallet_create", "market_list"]
+        # Also check for a subcommand to ensure group command processing works
+        self.assertTrue(len(self.generated_tool_names) > len(expected_cli_tool_names), 
+                        "Less tools generated than expected minimum (CLI + agent tools).")
+
+        for name in expected_cli_tool_names:
+            self.assertIn(name, self.generated_tool_names,
+                          f"Expected CLI command '{name}' not found in toolspec output.")
+
+    def test_get_url_lookup_schema_details(self):
+        spec = self.find_schema_by_name("get_url_lookup")
+        self.assertIsNotNone(spec, "Schema for 'get_url_lookup' not found.")
+        
+        # Compare docstring (stripping is important as inspect.getdoc might add newlines)
+        self.assertEqual(spec["description"], inspect.getdoc(get_url_lookup).strip(), 
+                         "Description mismatch for get_url_lookup")
+        
+        self.assertIn("url", spec["parameters"]["properties"])
+        self.assertEqual(spec["parameters"]["properties"]["url"]["type"], "string")
+        self.assertIn("url", spec["parameters"]["required"], "'url' should be a required parameter.")
+
+    def test_get_spam_score_schema_details(self):
+        spec = self.find_schema_by_name("get_spam_score")
+        self.assertIsNotNone(spec, "Schema for 'get_spam_score' not found.")
+        
+        self.assertEqual(spec["description"], inspect.getdoc(get_spam_score).strip(),
+                         "Description mismatch for get_spam_score")
+        
+        self.assertIn("url", spec["parameters"]["properties"])
+        self.assertEqual(spec["parameters"]["properties"]["url"]["type"], "string")
+        self.assertIn("url", spec["parameters"]["required"], "'url' should be a required parameter.")
+
+    def test_list_market_opportunities_schema_details(self):
+        spec = self.find_schema_by_name("list_market_opportunities")
+        self.assertIsNotNone(spec, "Schema for 'list_market_opportunities' not found.")
+
+        self.assertEqual(spec["description"], inspect.getdoc(list_market_opportunities).strip(), 
+                         "Description mismatch for list_market_opportunities")
+
+        params = spec["parameters"]["properties"]
+        self.assertIn("dr_min", params)
+        self.assertEqual(params["dr_min"]["type"], "integer")
+        self.assertIn("price_max", params)
+        self.assertEqual(params["price_max"]["type"], "number") # float maps to number
+        self.assertIn("topic", params)
+        self.assertEqual(params["topic"]["type"], "string")
+        
+        # Optional parameters should not be in 'required'
+        required_params = spec["parameters"].get("required", [])
+        self.assertNotIn("dr_min", required_params)
+        self.assertNotIn("price_max", required_params)
+        self.assertNotIn("topic", required_params)
+
+    def test_get_wallet_balance_schema_details(self):
+        spec = self.find_schema_by_name("get_wallet_balance")
+        self.assertIsNotNone(spec, "Schema for 'get_wallet_balance' not found.")
+        
+        self.assertEqual(spec["description"], inspect.getdoc(get_wallet_balance).strip(),
+                         "Description mismatch for get_wallet_balance")
+        
+        self.assertIn("wallet_id", spec["parameters"]["properties"])
+        self.assertEqual(spec["parameters"]["properties"]["wallet_id"]["type"], "string")
+        self.assertIn("wallet_id", spec["parameters"]["required"], "'wallet_id' should be a required parameter.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces new features to enable AI agents to interact programmatically with the aipseo SDK's core functionalities.

Key additions include:

1.  Agent Tools (`aipseo/agent_tools.py`):
    *   `get_url_lookup(url: str) -> dict`: Retrieves URL metadata.
    *   `get_spam_score(url: str) -> dict`: Fetches URL spam score.
    *   `list_market_opportunities(...) -> list`: Searches for backlink
        opportunities with optional filters.
    *   `get_wallet_balance(wallet_id: str) -> dict`: Gets wallet balance.
These functions use the existing `APIClient` for their operations.

2.  MCP Server (`aipseo/mcp_server.py`):
    *   A new MCP (Model Context Protocol) server is added to expose the
        functions in `agent_tools.py` as tools for AI agents.
    *   It can be run with `uvicorn aipseo.mcp_server:mcp_server`.

3.  Tool Specification (`aipseo/toolspec.py`):
    *   The `generate_openai_spec()` function is updated to generate
        OpenAI-compatible function schemas for the new agent tools,
        in addition to the existing CLI command schemas.
    *   Running `aipseo toolspec --format openai` now outputs schemas
        for both CLI and agent tools.

4.  Documentation (`AGENT.md`):
    *   The `AGENT.md` file has been updated to document the new
        agent tools, how to use them via the MCP server, and how to
        obtain their schemas using the `toolspec` command.

5.  Tests:
    *   Unit tests for all new functions in `aipseo/agent_tools.py`
        (mocking `APIClient`).
    *   A smoke test for `aipseo/mcp_server.py` to verify tool
        registration.
    *   Comprehensive tests for `aipseo/toolspec.py` to ensure correct
        schema generation for both CLI and new agent tools.

These changes significantly enhance the SDK's capabilities for programmatic integration by AI assistants and other automated systems.